### PR TITLE
NLM changes for lodestar base

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@
 target/
 out
 *~
+.settings/

--- a/lode-core-api/src/main/java/uk/ac/ebi/fgpt/lode/utils/GraphQueryFormats.java
+++ b/lode-core-api/src/main/java/uk/ac/ebi/fgpt/lode/utils/GraphQueryFormats.java
@@ -7,19 +7,25 @@ package uk.ac.ebi.fgpt.lode.utils;
  */
 public enum GraphQueryFormats {
 
-    RDFXML ("RDF/XML"),
-    N3 ("N3"),
-    JSON ("JSON-LD"),
-    TURTLE ("TURTLE");
+    RDFXML ("RDF/XML", "application/rdf+xml"),
+    N3 ("N3", "application/rdf+n3"),
+    JSON ("JSON-LD", "application/rdf+json"),
+    TURTLE ("TURTLE", "text/turtle");
 
     private final String format;
+    private final String mimetype;
 
-    private GraphQueryFormats(final String format) {
-        this.format = format;
+    private GraphQueryFormats(final String format, final String mimetype) {
+	this.format = format;
+	this.mimetype = mimetype;
     }
 
     @Override
     public String toString() {
         return format;
+    }
+
+    public String toMimeType() {
+        return mimetype;
     }
 }

--- a/lode-core-api/src/main/java/uk/ac/ebi/fgpt/lode/utils/TupleQueryFormats.java
+++ b/lode-core-api/src/main/java/uk/ac/ebi/fgpt/lode/utils/TupleQueryFormats.java
@@ -8,20 +8,26 @@ package uk.ac.ebi.fgpt.lode.utils;
 public enum TupleQueryFormats{
 
 
-    XML ("XML"),
-    CSV ("CSV"),
-    TSV ("TSV"),
-    JSON ("JSON");
+    XML ("XML", "application/sparql-results+xml"),
+    CSV ("CSV", "text/csv"),
+    TSV ("TSV", "text/tab-separated-values"),
+    JSON ("JSON", "application/sparql-results+json");
 
 
     private final String format;
+    private final String mimetype;
 
-    private TupleQueryFormats(String format) {
+    private TupleQueryFormats(String format, String mimetype) {
         this.format = format;
+	this.mimetype = mimetype;
     }
 
     @Override
     public String toString() {
         return format;
+    }
+
+    public String toMimeType() {
+	return mimetype;
     }
 }

--- a/lode-core-servlet/src/main/java/uk/ac/ebi/fgpt/lode/servlet/ExplorerServlet.java
+++ b/lode-core-servlet/src/main/java/uk/ac/ebi/fgpt/lode/servlet/ExplorerServlet.java
@@ -15,8 +15,10 @@ package uk.ac.ebi.fgpt.lode.servlet;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Controller;
+import org.springframework.web.servlet.ModelAndView;
 import org.springframework.web.bind.annotation.*;
 import uk.ac.ebi.fgpt.lode.exception.LodeException;
 import uk.ac.ebi.fgpt.lode.model.ShortResourceDescription;
@@ -47,6 +49,9 @@ public class ExplorerServlet {
     private ExploreService service;
     private SparqlService sparqlService;
 
+    @Value("${lode.explorer.service.baseuri}")
+    private URI baseUri;
+
     public SparqlService getSparqlService() {
         return sparqlService;
     }
@@ -74,8 +79,28 @@ public class ExplorerServlet {
         this.configuration = configuration;
     }
 
+    public URI getBaseUri() {
+        return this.baseUri;
+    }
+
+    public void setBaseUri(URI baseUri) {
+        this.baseUri = baseUri;
+    }
+
     protected Logger getLog() {
         return log;
+    }
+
+    protected URI resolveUri(String reluri) {
+        if (reluri == null || reluri.length() == 0) {
+            return null;
+        }
+        else if (baseUri != null) {
+            return baseUri.resolve(reluri);
+        }
+        else {
+            return URI.create(reluri);
+        }
     }
 
     @RequestMapping (produces="application/rdf+xml")
@@ -83,9 +108,10 @@ public class ExplorerServlet {
     void describeResourceAsXml (
             @RequestParam(value = "uri", required = true ) String uri,
             HttpServletResponse response) throws IOException, LodeException {
-        if (uri != null && uri.length() > 0) {
-            String query = "DESCRIBE <" + URI.create(uri) + ">";
-            response.setContentType("application/rdf+xml");
+        URI absuri = this.resolveUri(uri);
+        if (absuri != null) {
+            String query = "DESCRIBE <" + absuri + ">";
+            response.setContentType("application/rdf+xml; charset=utf-8");
             ServletOutputStream out = response.getOutputStream();
             out.println();
             out.println();
@@ -93,7 +119,7 @@ public class ExplorerServlet {
             out.close();
         }
         else {
-
+            handleBadUriException(new Exception("Malformed or empty ID request: " + uri));
         }
     }
 
@@ -102,10 +128,11 @@ public class ExplorerServlet {
     void describeResourceAsN3 (
             @RequestParam(value = "uri", required = true ) String uri,
             HttpServletResponse response) throws IOException, LodeException {
-        if (uri != null && uri.length() > 0) {
-            String query = "DESCRIBE <" + URI.create(uri) + ">";
+        URI absuri = resolveUri(uri);
+        if (absuri != null) {
+            String query = "DESCRIBE <" + absuri + ">";
             log.trace("querying for graph n3");
-            response.setContentType("text/n3");
+            response.setContentType("text/n3; charset=utf-8");
             ServletOutputStream out = response.getOutputStream();
             out.println();
             out.println();
@@ -122,10 +149,11 @@ public class ExplorerServlet {
     void describeResourceAsTurtle (
             @RequestParam(value = "uri", required = true ) String uri,
             HttpServletResponse response) throws IOException, LodeException {
-        if (uri != null && uri.length() > 0) {
-            String query = "DESCRIBE <" + URI.create(uri) + ">";
+        URI absuri = this.resolveUri(uri);
+        if (absuri != null) {
+            String query = "DESCRIBE <" + absuri + ">";
             log.trace("querying for graph turtle");
-            response.setContentType("text/turtle");
+            response.setContentType("text/turtle; charset=utf-8");
             ServletOutputStream out = response.getOutputStream();
             out.println();
             out.println();
@@ -142,10 +170,11 @@ public class ExplorerServlet {
     void describeResourceAsJson (
             @RequestParam(value = "uri", required = true ) String uri,
             HttpServletResponse response) throws IOException, LodeException {
-        if (uri != null && uri.length() > 0) {
-            String query = "DESCRIBE <" + URI.create(uri) + ">";
+        URI absuri = resolveUri(uri);
+        if (absuri != null) {
+            String query = "DESCRIBE <" + absuri + ">";
             log.trace("querying for graph rdf+n3");
-            response.setContentType("application/rdf+json");
+            response.setContentType("application/rdf+json; charset=utf-8");
             ServletOutputStream out = response.getOutputStream();
             out.println();
             out.println();
@@ -157,24 +186,70 @@ public class ExplorerServlet {
         }
     }
 
+    @RequestMapping (produces="text/plain")
+    public @ResponseBody
+    void describeResourceAsNtriples (
+            @RequestParam(value = "uri", required = true ) String uri,
+            HttpServletResponse response) throws IOException, LodeException {
+        URI absuri = resolveUri(uri);
+        if (absuri != null) {
+            String query = "DESCRIBE <" + absuri + ">";
+            log.info("querying for graph rdf+ntriples");
+            response.setContentType("text/plain; charset=utf-8");
+            ServletOutputStream out = response.getOutputStream();
+            out.println();
+            out.println();
+            getSparqlService().query(query, "N-TRIPLES", false, out);
+            out.close();
+        }
+        else {
+            handleBadUriException(new Exception("Malformed or empty URI request: " + uri));
+        }
+    }
+
+    @RequestMapping
     public @ResponseBody
     void describeResource (
             @RequestParam(value = "uri", required = true ) String uri,
             @RequestParam(value = "format", required = false ) String format,
             HttpServletResponse response) throws IOException, LodeException {
-        if (uri != null && uri.length() > 0) {
-            if (format.toLowerCase().equals("n3")) {
-                describeResourceAsN3(uri, response);
-            }
-            else if (format.toLowerCase().equals("json-ld")) {
-                describeResourceAsJson(uri, response);
-            }
-            else {
-                describeResourceAsXml(uri, response);
-            }
+        if (format == null) {
+            describeResourceAsNtriples(uri, response);
+        } else if (format.toLowerCase().equals("rdf") ||
+                   format.toLowerCase().equals("xml") ||
+                   format.toLowerCase().equals("rdf/xml")) {
+            describeResourceAsXml(uri, response);
+        }
+        else if (format.toLowerCase().equals("n3")) {
+            describeResourceAsN3(uri, response);
+        }
+        else if (format.toLowerCase().equals("ttl") || format.toLowerCase().equals("turtle")) {
+            describeResourceAsTurtle(uri, response);
+        }
+        else if (format.toLowerCase().equals("json") || format.toLowerCase().equals("json-ld")) {
+            describeResourceAsJson(uri, response);
         }
         else {
-            handleBadUriException(new Exception("Malformed or empty URI request: " + uri));
+            describeResourceAsNtriples(uri, response);
+        }
+    }
+
+    @RequestMapping(value = "/html", method = RequestMethod.GET)
+    public ModelAndView describeResourceAsHtml(
+            @RequestParam(value = "uri", required = true ) String uri,
+            @RequestParam(value = "resource_prefix", required = false) String resource_prefix) throws LodeException {
+        URI absuri = resolveUri(uri);
+        if (absuri != null) {
+            ModelAndView mv = new ModelAndView();
+            mv.setViewName("explore");
+            if (resource_prefix == null) {
+                resource_prefix = "";
+            }
+            mv.addObject("uri", absuri.toString());
+            mv.addObject("resource_prefix", resource_prefix);
+            return mv;
+        } else {
+            throw new LodeException("Malformed or empty URI request: " + uri);
         }
     }
 
@@ -182,9 +257,10 @@ public class ExplorerServlet {
     public @ResponseBody Collection<RelatedResourceDescription> getTypesWithLabelsAndDescription(
             @RequestParam(value = "uri", required = true ) String uri) throws LodeException {
 
-        if (uri != null && uri.length() > 0) {
+        URI absuri = resolveUri(uri);
+        if (absuri != null) {
             return getService().getTypes(
-                    URI.create(uri),
+                    absuri,
                     getConfiguration().getIgnoreTypes(),
                     getConfiguration().ignoreBlankNodes()
                     );
@@ -198,9 +274,10 @@ public class ExplorerServlet {
     public @ResponseBody Collection<RelatedResourceDescription> getAllTypesWithLabelsAndDescription(
             @RequestParam(value = "uri", required = true ) String uri) throws LodeException {
 
-        if (uri != null && uri.length() > 0) {
+        URI absuri = resolveUri(uri);
+        if (absuri != null) {
             return getService().getAllTypes(
-                    URI.create(uri),
+                    absuri,
                     getConfiguration().getIgnoreTypes(),
                     getConfiguration().ignoreBlankNodes()
                     );
@@ -213,13 +290,15 @@ public class ExplorerServlet {
     @RequestMapping(value = "/relatedToObjects", method = RequestMethod.GET)
     public @ResponseBody Collection<RelatedResourceDescription> getRelatedToObjects(
             @RequestParam(value = "uri", required = true ) String uri) throws LodeException {
-        if (uri != null && uri.length() > 0) {
+
+         URI absuri = resolveUri(uri);
+         if (absuri != null) {
             // get the relationships to ignore
             Set<URI> ignoreProps = getConfiguration().getIgnoreRelationships();
             ignoreProps.addAll(getConfiguration().getTopRelationships());
 
             return getService().getRelatedToObjects(
-                    URI.create(uri),
+                    absuri,
                     ignoreProps,
                     getConfiguration().getIgnoreTypes(),
                     getConfiguration().ignoreBlankNodes());
@@ -235,9 +314,10 @@ public class ExplorerServlet {
 
         getLog().trace("Getting short description for: " + uri);
 
-        if (uri != null && uri.length() > 0) {
+        URI absuri = resolveUri(uri);
+        if (absuri != null) {
             return getService().getShortResourceDescription(
-                    URI.create(uri),
+                    absuri,
                     getConfiguration().getLabelRelations(),
                     getConfiguration().getDescriptionRelations()
             );
@@ -254,10 +334,11 @@ public class ExplorerServlet {
 
         getLog().trace("Getting image urls for: " + uri);
         Set<DepictionBean> dps= new HashSet<DepictionBean>();
-        if (uri != null && uri.length() > 0) {
 
+        URI absuri = resolveUri(uri);
+        if (absuri != null) {
             for (String u :  getService().getResourceDepiction(
-                    URI.create(uri),
+                    absuri,
                     getConfiguration().getDepictRelation())) {
                 dps.add(new DepictionBean(u));
             }
@@ -274,13 +355,14 @@ public class ExplorerServlet {
 
         getLog().trace("Getting top objects for: " + uri);
 
-        if (uri != null && uri.length() > 0) {
+        URI absuri = resolveUri(uri);
+        if (absuri != null) {
             Set<URI> toprelations = new LinkedHashSet<URI>(getConfiguration().getTopRelationships());
             return getService().getRelatedResourceByProperty(
-                    URI.create(uri),
+                    absuri,
                     toprelations,
-                           getConfiguration().getIgnoreTypes(),
-                            getConfiguration().ignoreBlankNodes());
+                    getConfiguration().getIgnoreTypes(),
+                    getConfiguration().ignoreBlankNodes());
         }
         else {
             return Collections.emptyList();
@@ -291,9 +373,11 @@ public class ExplorerServlet {
     @RequestMapping("/relatedFromSubjects")
     public @ResponseBody Collection<RelatedResourceDescription> getRelatedFromSubjects(
             @RequestParam(value = "uri", required = true ) String uri) throws LodeException {
-        if (uri != null && uri.length() > 0) {
+
+        URI absuri = resolveUri(uri);
+        if (absuri != null) {
             return getService().getRelatedFromSubjects(
-                    URI.create(uri),
+                    absuri,
                     new HashSet<URI>(),
                     getConfiguration().getIgnoreTypes(),
                     getConfiguration().ignoreBlankNodes());

--- a/pom.xml
+++ b/pom.xml
@@ -15,7 +15,8 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <org.springframework.version>3.2.2.RELEASE</org.springframework.version>
-        <org.slf4j.version>1.6.4</org.slf4j.version>
+        <org.slf4j.version>1.7.12</org.slf4j.version>
+        <log4j.version>1.2.17</log4j.version>
     </properties>
 
 
@@ -132,7 +133,7 @@
         <dependency>
             <groupId>log4j</groupId>
             <artifactId>log4j</artifactId>
-            <version>1.2.16</version>
+            <version>${log4j.version}</version>
             <scope>test</scope>
         </dependency>
 
@@ -160,7 +161,7 @@
             <dependency>
                 <groupId>log4j</groupId>
                 <artifactId>log4j</artifactId>
-                <version>1.2.16</version>
+                <version>${log4j.version}</version>
                 <scope>test</scope>
                 <!-- override test scope if required for CLI, webapp modules -->
             </dependency>

--- a/web-ui/pom.xml
+++ b/web-ui/pom.xml
@@ -23,8 +23,7 @@
         <dependency>
             <groupId>log4j</groupId>
             <artifactId>log4j</artifactId>
-            <version>1.2.16</version>
-
+            <version>${log4j.version}</version>
             <scope>runtime</scope>
         </dependency>
 
@@ -35,6 +34,22 @@
             <scope>runtime</scope>
         </dependency>
 
+        <!-- NOTE: Tomcat 7 is providing JSP API 3.0; be careful -->
+        <dependency>
+            <groupId>javax.servlet</groupId>
+            <artifactId>servlet-api</artifactId>
+            <version>2.5</version>
+            <scope>provided</scope>
+        </dependency>
+
+        <!-- NOTE: Tomcat 7 is providing JSP API 2.2; be careful -->
+        <dependency>
+            <groupId>javax.servlet</groupId>
+            <artifactId>jsp-api</artifactId>
+            <version>2.0</version>
+            <scope>provided</scope>
+        </dependency>
+
         <dependency>
             <groupId>ebi-lode</groupId>
             <artifactId>lode-core-servlet</artifactId>
@@ -42,9 +57,9 @@
         </dependency>
 
         <dependency>
-        <groupId>org.tuckey</groupId>
-        <artifactId>urlrewritefilter</artifactId>
-        <version>4.0.3</version>
+            <groupId>org.tuckey</groupId>
+            <artifactId>urlrewritefilter</artifactId>
+            <version>4.0.3</version>
         </dependency>
 
     </dependencies>

--- a/web-ui/src/main/webapp/WEB-INF/ebi-lode-service.xml
+++ b/web-ui/src/main/webapp/WEB-INF/ebi-lode-service.xml
@@ -12,6 +12,11 @@
 
     <bean name="explorerConfig" class="uk.ac.ebi.fgpt.lode.impl.DefaultExplorerViewConfigImpl"/>
 
+    <!--
+      NOTE: This bean is not really used.   The Spring MVC DispatcherServlet loads looks
+      at lode-servlet.xml, it is the child context, and is getting an autowired bean.
+      Probably don't much in ebi-lode-service.xml
+     -->
     <bean id="serviceServlet" class="uk.ac.ebi.fgpt.lode.servlet.ExplorerServlet">
         <property name="sparqlService" ref="jenaSparqlService"/>
         <property name="configuration" ref="explorerConfig"/>

--- a/web-ui/src/main/webapp/WEB-INF/lode-servlet.xml
+++ b/web-ui/src/main/webapp/WEB-INF/lode-servlet.xml
@@ -11,6 +11,9 @@
        http://www.springframework.org/schema/mvc
        http://www.springframework.org/schema/mvc/spring-mvc-3.0.xsd">
 
+    <!-- Load properties from lode.properties -->
+    <context:property-placeholder location="classpath:lode.properties"/>
+
     <!-- autowire this context only (just controllers, not services) based on annotations -->
     <context:annotation-config />
 

--- a/web-ui/src/main/webapp/WEB-INF/web.xml
+++ b/web-ui/src/main/webapp/WEB-INF/web.xml
@@ -1,19 +1,16 @@
-<!DOCTYPE web-app PUBLIC
-        "-//Sun Microsystems, Inc.//DTD Web Application 2.3//EN"
-        "http://java.sun.com/dtd/web-app_2_3.dtd" >
-
-<web-app xmlns="http://java.sun.com/xml/ns/j2ee"
+<web-app xmlns="http://java.sun.com/xml/ns/javaee"
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="
-         http://java.sun.com/xml/ns/j2ee
-         http://java.sun.com/xml/ns/j2ee/web-app_2_4.xsd"
-         version="2.4">
+         http://java.sun.com/xml/ns/javaee
+         http://java.sun.com/xml/ns/javaee/web-app_3_0.xsd"
+         version="3.0">
     <display-name>EBI - Linked Data Explorer</display-name>
 
 
     <description>
         SPARQL endpoint and Linked Data Browser
     </description>
+
     <!--Define configuration to load-->
     <context-param>
         <param-name>contextConfigLocation</param-name>


### PR DESCRIPTION
These changes are designed to accomplish the following:

* Improve MIME type handling for each graph and tuple format, by:
   - centralizing these MIME types into the enums for the graph and tuple formats
   - adding a charset UTF-8 on each format
   - The MIME type must then be taken from the enum by the `SparqlServlet`.
* Enhance the `ExplorerServlet` to allow use of Spring normal view resolution (and thus templates such as JSPs) when `urlrewrite.xml` is modified to direct requests for HTML to the appropriate URL.   This method also supports a  `resource_prefix` parameter that allows lodestar to use only relative URIs for assets such as CSS and JavaScript.
* Enhance the `ExplorerServlet` so that the `uri` parameter given to many methods may be a relative URI (for an entity in the triplestore) resolved against a baseURI provided by the Spring configuration.
* Enhance the `ExplorerServlet` to add support for different formats such as RDF/XML using semantic URLs ending in `.rdf` or `.xml` in addition to using the `Accept` request header.
* Update the dependencies a bit to:
    - Assume Tomcat 7 is the minimum version used
    - Change log4j and slf4j so that Java melody can be more easily added on top.

Changes to the web-ui submodule are minimal, because the assumption is that custom changes can be accomplished using the WAR overlay technique supported by the `maven-war-plugin`.   This provides an ideal method for down-stream users to leverage Lodestar.   https://github.com/HHS/meshrdf contains an example in the `webui` directory.