### PR TITLE
Update versions of libraries to mitigate security issues

### DIFF
--- a/lode-core-api/pom.xml
+++ b/lode-core-api/pom.xml
@@ -26,10 +26,10 @@
 
 
         <dependency>
-        <groupId>org.apache.jena</groupId>
-        <artifactId>apache-jena-libs</artifactId>
-        <version>2.12.0</version>
-        <type>pom</type>
+            <groupId>org.apache.jena</groupId>
+            <artifactId>apache-jena-libs</artifactId>
+            <version>2.12.0</version>
+            <type>pom</type>
         </dependency>
 
 
@@ -45,6 +45,45 @@
             <artifactId>json</artifactId>
             <version>20090211</version>
         </dependency>
+
+        <!-- Override Jena dependencies on versions of httpclient and jackson with CVEs -->
+        <dependency>
+            <groupId>org.apache.httpcomponents</groupId>
+            <artifactId>httpclient</artifactId>
+            <version>4.5.2</version>
+        </dependency>
+
+        <dependency>
+            <groupId>com.github.jsonld-java</groupId>
+            <artifactId>jsonld-java</artifactId>
+            <version>0.8.3</version>
+        </dependency>
+
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.8.4</version>
+        </dependency>
+
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+            <version>2.8.4</version>
+        </dependency>
+
+        <!--
+        <dependency>
+            <groupId>org.codehaus.jackson</groupId>
+            <artifactId>jackson-mapper-asl</artifactId>
+            <version>1.9.13</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.codehaus.jackson</groupId>
+            <artifactId>jackson-core-asl</artifactId>
+            <version>1.9.13</version>
+        </dependency>
+        -->
 
         <dependency>
             <groupId>commons-logging</groupId>

--- a/lode-virtuoso-impl/src/main/java/uk/ac/ebi/fgpt/lode/impl/VirtuosoDatasourceProvider.java
+++ b/lode-virtuoso-impl/src/main/java/uk/ac/ebi/fgpt/lode/impl/VirtuosoDatasourceProvider.java
@@ -30,15 +30,14 @@ import java.sql.SQLException;
 public class VirtuosoDatasourceProvider implements DatasourceProvider {
     private Logger logger = LoggerFactory.getLogger(getClass());
 
-    private VirtuosoDataSource virtuosoSource = null;
+    private DataSource dataSource = null;
 
     public VirtuosoDatasourceProvider() {
         // Get the DataSource using JNDI
-        if (virtuosoSource == null) {
+        if (dataSource == null) {
             try {
                 Context context = (Context) (new InitialContext()).lookup("java:comp/env");
-                virtuosoSource = (VirtuosoDataSource) context.lookup("jdbc/virtuoso");
-
+                dataSource = (DataSource) context.lookup("jdbc/virtuoso");
             }
             catch (NamingException e) {
                 throw new IllegalStateException("Virtuoso JNDI datasource not configured: " + e.getMessage());
@@ -49,13 +48,14 @@ public class VirtuosoDatasourceProvider implements DatasourceProvider {
     public VirtuosoDatasourceProvider(String endpointUrl, int port) {
 
         // Get the DataSource
-        if (virtuosoSource == null) {
+        if (dataSource == null) {
             try {
                 Context context = (Context) (new InitialContext()).lookup("java:comp/env");
-                virtuosoSource = (VirtuosoDataSource) context.lookup("jdbc/virtuoso");
-
+                // NOTE: If we need setServerName() and setPortNumber(), we insist on the real thing
+                VirtuosoDataSource virtuosoSource = (VirtuosoDataSource) context.lookup("jdbc/virtuoso");
                 virtuosoSource.setServerName(endpointUrl);
                 virtuosoSource.setPortNumber(port);
+                dataSource = virtuosoSource;
             }
             catch (NamingException e) {
                 throw new IllegalStateException("Virtuoso JNDI datasource not configured: " + e.getMessage());
@@ -64,6 +64,6 @@ public class VirtuosoDatasourceProvider implements DatasourceProvider {
     }
 
     public DataSource getDataSource() throws SQLException {
-        return virtuosoSource;
+        return dataSource;
     }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -14,7 +14,7 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <org.springframework.version>3.2.2.RELEASE</org.springframework.version>
+        <org.springframework.version>4.3.3.RELEASE</org.springframework.version>
         <org.slf4j.version>1.7.12</org.slf4j.version>
         <log4j.version>1.2.17</log4j.version>
     </properties>
@@ -46,6 +46,21 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-site-plugin</artifactId>
                 <version>3.0</version>
+            </plugin>
+            <plugin>
+                <groupId>org.owasp</groupId>
+                <artifactId>dependency-check-maven</artifactId>
+                <version>1.4.3</version>
+                <configuration>
+                    <cveValidForHours>12</cveValidForHours>
+                </configuration>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>check</goal>
+                        </goals>
+                    </execution>
+                </executions>
             </plugin>
         </plugins>
         <extensions>


### PR DESCRIPTION
Addresses EBISPOT/lodestar#20 by updating spring, and overriding some of the libraries depended on by other libraries so as to avoid CVEs.  Apache Jena itself is not patched as Virt-jena does not claim support for anything past jena 2.6.2, and we are already using jena 2.12.0.   Attempts to build with jena 2.13.0 worked.   Selenium driven tests of MeSH RDF worked after these patches.

These library version numbers could be pushed up to the master pom as properties.

This includes the changes in pull request #17 which can be separated if desirable.